### PR TITLE
Initial project scaffold with content and config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Create a report to help improve the site
+---
+
+**Describe the bug**
+
+**Steps to reproduce**
+
+**Expected behavior**
+
+**Environment**
+- OS:
+- Browser:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for the FOSS Soft Robotics site
+---
+
+**Problem**
+
+**Proposed solution**
+
+**Alternatives**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on:
+  push:
+    branches: [ main, V0.2-Content ]
+  pull_request:
+    branches: [ main, V0.2-Content ]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List files
+        run: ls -la

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Node / tooling
+node_modules/
+.npm/
+.pnpm-store/
+dist/
+.build/
+.out/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/*
+!.vscode/settings.json
+
+# Env
+.env
+.env.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+.build
+.out
+public/assets/downloads

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.eol": "\n",
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2
+}

--- a/content/blog/2025-10-02-welcome.md
+++ b/content/blog/2025-10-02-welcome.md
@@ -1,0 +1,8 @@
+---
+title: "Welcome to FOSS Soft Robotics"
+date: "2025-10-02"
+tags: ["meta"]
+summary: "Initial scaffold and content-first approach."
+---
+
+This is a starter post. Replace with real content.

--- a/content/projects/overview.md
+++ b/content/projects/overview.md
@@ -1,0 +1,7 @@
+---
+title: "Project Overview"
+summary: "Catalog of example builds, code, and teaching modules."
+status: "draft"
+---
+
+Describe the scope of projects/modules here.

--- a/content/research/scope.md
+++ b/content/research/scope.md
@@ -1,0 +1,5 @@
+---
+title: "Research Scope"
+---
+
+High-level topics, references, and reading lists.

--- a/data/publications.yaml
+++ b/data/publications.yaml
@@ -1,0 +1,5 @@
+- year: 2025
+  title: "Ultra-Resilient Dielectric Elastomer Actuators"
+  venue: "ASME SMASIS"
+  authors: ["A. Gogoj", "…"]
+  link: "#"

--- a/data/talks.yaml
+++ b/data/talks.yaml
@@ -1,0 +1,4 @@
+- date: "2025-09-22"
+  title: "Soft Robotics in Extreme Environments"
+  event: "SMASIS 2025"
+  slides: "#"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+Content lives in `content/`. Static files in `public/`. HTML pages in `src/pages/`.
+You can swap in a static site generator later without moving the content.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+- Open an issue before large changes.
+- Use feature branches; open PRs into `V0.2-Content` (or `main` later).

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Minimal build: copies src/pages and public into ./dist
+rm -rf dist
+mkdir -p dist
+cp -r src/pages/* dist/ 2>/dev/null || true
+mkdir -p dist/styles dist/scripts dist/assets
+cp -r src/styles/* dist/styles/ 2>/dev/null || true
+cp -r src/scripts/* dist/scripts/ 2>/dev/null || true
+cp -r public/* dist/ 2>/dev/null || true
+echo "Built to ./dist"

--- a/scripts/dev_checklist.md
+++ b/scripts/dev_checklist.md
@@ -1,0 +1,5 @@
+# Dev Checklist
+- [ ] Choose a static site generator (Astro/Next.js/Hugo) or keep vanilla
+- [ ] Wire content in `content/` into pages
+- [ ] Replace placeholders and metadata
+- [ ] Set up GitHub Pages or deployment target

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>404 — Not Found</title><link rel="stylesheet" href="/styles/main.css"></head>
+<body><main><h1>404</h1><p>Page not found.</p></main></body>
+</html>

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>About — FOSS Soft Robotics</title><link rel="stylesheet" href="/styles/main.css"></head>
+<body><main><h1>About</h1><p>An open, community-driven textbook/resource for soft robotics.</p></main></body>
+</html>

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Contact</title><link rel="stylesheet" href="/styles/main.css"></head>
+<body><main><h1>Contact</h1><p>Open an issue on GitHub or reach out via the project README.</p></main></body>
+</html>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FOSS Soft Robotics — Home</title>
+  <link rel="stylesheet" href="/styles/main.css" />
+  <script defer src="/scripts/site.js"></script>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/">Home</a> ·
+      <a href="/about.html">About</a> ·
+      <a href="/contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>FOSS Soft Robotics</h1>
+    <p>Free & open-source resources for learning and teaching soft robotics.</p>
+  </main>
+  <footer><small>© 2025 FOSS Soft Robotics</small></footer>
+</body>
+</html>

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -1,0 +1,2 @@
+// Site-wide JS placeholder
+console.log("FOSS Soft Robotics site loaded");

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,7 @@
+:root { --max-width: 72ch; }
+* { box-sizing: border-box; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; line-height: 1.6; }
+main { max-width: var(--max-width); margin: 2rem auto; padding: 0 1rem; }
+header, footer { background: #f6f6f6; padding: 1rem; }
+nav a { margin-right: .75rem; text-decoration: none; }
+nav a:hover { text-decoration: underline; }


### PR DESCRIPTION
Add project structure including editor and formatting configs, GitHub issue templates, CI workflow, and .gitignore. Introduce initial content for blog, projects, and research, as well as data files for publications and talks. Provide documentation for architecture and contributing, static HTML pages, basic CSS and JS, and build/dev scripts.