### PR TITLE
Add Jekyll site structure and content

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,16 @@
+title: "FOSS Soft Robotics"
+description: "Free & open resources for soft robotics."
+theme: minima
+
+# Top nav: these files (at docs/ root) will appear as header links
+header_pages:
+  - projects.md
+  - research.md
+  - blog.md
+  - media.md
+  - contact.md
+
+# Useful options
+markdown: kramdown
+kramdown:
+  input: GFM

--- a/docs/_posts/2025-10-02-welcome.md
+++ b/docs/_posts/2025-10-02-welcome.md
@@ -1,0 +1,5 @@
+---
+title: "Welcome to the FOSS Soft Robotics site"
+---
+
+Initial scaffold is live. We’ll keep adding projects, labs, and reference material.

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+Latest posts:
+
+<ul>
+{%- for post in site.posts -%}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <small> — {{ post.date | date: "%Y-%m-%d" }}</small>
+  </li>
+{%- endfor -%}
+</ul>

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Contact
+permalink: /contact/
+---
+
+Open an issue on GitHub or reach out via the repository README.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+---
+layout: home
+title: Home
+---
+
+Welcome! Use the tabs above to explore Projects, Research, Blog, and Media.

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Media
+permalink: /media/
+---
+
+Slides, images, and downloads:
+
+<ul>
+{%- assign pages = site.pages | where_exp: "p", "p.url contains '/media/' and p.url != '/media/'" | sort: "title" -%}
+{%- for p in pages -%}
+  <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+{%- endfor -%}
+</ul>

--- a/docs/media/slide-deck.md
+++ b/docs/media/slide-deck.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: SMASIS 2025 Slide Deck
+---
+
+Link to slides or upload assets into `/media/assets/`.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+---
+
+Below are all project pages living under `/projects/`:
+
+<ul>
+{%- assign pages = site.pages | where_exp: "p", "p.url contains '/projects/' and p.url != '/projects/'" | sort: "title" -%}
+{%- for p in pages -%}
+  <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+{%- endfor -%}
+</ul>

--- a/docs/projects/tooling.md
+++ b/docs/projects/tooling.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Tooling & Fixtures
+---
+
+Build notes and printable fixtures used across the curriculum.

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Research
+permalink: /research/
+---
+
+A collection of research notes and summaries:
+
+<ul>
+{%- assign pages = site.pages | where_exp: "p", "p.url contains '/research/' and p.url != '/research/'" | sort: "title" -%}
+{%- for p in pages -%}
+  <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+{%- endfor -%}
+</ul>

--- a/docs/research/ultra-resilient-dea.md
+++ b/docs/research/ultra-resilient-dea.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Ultra-Resilient Dielectric Elastomer Actuators
+---
+
+Short abstract and links to papers/slides.


### PR DESCRIPTION
Introduces the initial scaffold for the FOSS Soft Robotics documentation site using Jekyll. Adds configuration, navigation, and starter content for blog, projects, research, media, and contact pages, along with example subpages for each section.