### PR TITLE
Refactor media, projects, and research page templates

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -4,11 +4,21 @@ title: Media
 permalink: /media/
 ---
 
-Slides, images, and downloads:
+## Logos & Branding
+<!-- Put PNG/SVG assets in /docs/assets/images or /docs/media -->
 
+## Slide Decks
+<!-- Upload to /docs/media or link externally -->
+
+## Photos & Figures
+<!-- Thumbnails + captions -->
+
+## All Media Pages
 <ul>
-{%- assign pages = site.pages | where_exp: "p", "p.url contains '/media/' and p.url != '/media/'" | sort: "title" -%}
+{%- assign pages = site.pages | where: "dir", "/media/" | sort: "title" -%}
 {%- for p in pages -%}
+  {%- unless p.url == "/media/" -%}
   <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+  {%- endunless -%}
 {%- endfor -%}
 </ul>

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -4,11 +4,15 @@ title: Projects
 permalink: /projects/
 ---
 
-Below are all project pages living under `/projects/`:
+## Overview
+<!-- What counts as a "project"? Expected outcomes? -->
 
+## All Projects
 <ul>
-{%- assign pages = site.pages | where_exp: "p", "p.url contains '/projects/' and p.url != '/projects/'" | sort: "title" -%}
+{%- assign pages = site.pages | where: "dir", "/projects/" | sort: "title" -%}
 {%- for p in pages -%}
+  {%- unless p.url == "/projects/" -%}
   <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+  {%- endunless -%}
 {%- endfor -%}
 </ul>

--- a/docs/research.md
+++ b/docs/research.md
@@ -4,11 +4,15 @@ title: Research
 permalink: /research/
 ---
 
-A collection of research notes and summaries:
+## Themes
+<!-- e.g., DEAs in extreme environments, materials discovery, etc. -->
 
+## Notes & Summaries
 <ul>
-{%- assign pages = site.pages | where_exp: "p", "p.url contains '/research/' and p.url != '/research/'" | sort: "title" -%}
+{%- assign pages = site.pages | where: "dir", "/research/" | sort: "title" -%}
 {%- for p in pages -%}
+  {%- unless p.url == "/research/" -%}
   <li><a href="{{ p.url | relative_url }}">{{ p.title | default: p.url }}</a></li>
+  {%- endunless -%}
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
Updated the templates for media, projects, and research pages to use the 'where: "dir"' filter for listing subpages, added section headers and comments for better organization, and excluded the main index page from the lists. This improves maintainability and clarity of the documentation structure.