### PR TITLE
Update module links to use Sphinx doc syntax

### DIFF
--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -4,8 +4,8 @@ title: Modules
 
 ## All Modules
 
-- [Module 01](01-actuators-101)
-- [Module 02](02-fabrication-basics)
-- [Module 03](03-modeling-control)
-- [Module 04](04-materials-data)
+- {doc}`Module 01 <01-actuators-101.md>`
+- {doc}`Module 02 <02-fabrication-basics.md>`
+- {doc}`Module 03 <03-modeling-control.md>`
+- {doc}`Module 04 <04-materials-data.md>`
 


### PR DESCRIPTION
Changed module links in docs/modules/index.md to use Sphinx's {doc} directive for improved documentation navigation and consistency.