### PR TITLE
Quote YAML titles in module markdown files

### DIFF
--- a/docs/modules/01-actuators-101.md
+++ b/docs/modules/01-actuators-101.md
@@ -1,5 +1,5 @@
 ---
-title: Module 01: Actuators 101
+title: "Module 01: Actuators 101"
 ---
 
 ## Module 01: Actuators 101

--- a/docs/modules/02-fabrication-basics.md
+++ b/docs/modules/02-fabrication-basics.md
@@ -1,5 +1,5 @@
 ---
-title: Module 02: Fabrication Basics
+title: "Module 02: Fabrication Basics"
 ---
 
 ## Module 02: Fabrication Basics

--- a/docs/modules/03-modeling-control.md
+++ b/docs/modules/03-modeling-control.md
@@ -1,5 +1,5 @@
 ---
-title: Module 03: Modeling & Control
+title: "Module 03: Modeling & Control"
 ---
 
 ## Module 03: Modeling & Control

--- a/docs/modules/04-materials-data.md
+++ b/docs/modules/04-materials-data.md
@@ -1,5 +1,5 @@
 ---
-title: Module 04: Materials Data
+title: "Module 04: Materials Data"
 ---
 
 ## Module 04: Materials Data


### PR DESCRIPTION
Added quotes around the 'title' fields in the YAML front matter of module documentation files for consistency and to prevent potential parsing issues.